### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Create .gitattributes with the appropriate line to enable solidity syntax highlighting in the github web ui, as per github/linguist#3973